### PR TITLE
vtg 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ bytes = "1.6.0"
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1.1"
 tokio = { version = "1.42.0", features = ["full"] }
-form_urlencoded = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.4.0", features = ["macros"] }
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ categories = ["web-programming", "api-bindings"]
 [dependencies]
 hyper-tls = { version = "0.6.0", features = ["alpn"] }
 serde_json = "1.0.105"
-hyper = { version = "1.3.1", features = ["full"] }
+hyper = { version = "1.5.2", features = ["full"] }
 bytes = "1.6.0"
 hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1.1"
-tokio = { version = "1.37.0", features = ["full"] }
-form_urlencoded = "1.2.0"
+tokio = { version = "1.42.0", features = ["full"] }
+form_urlencoded = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = { version = "3.4.0", features = ["macros"] }
 lazy_static = "1.4.0"
@@ -30,3 +30,8 @@ log = "0.4"
 [dev-dependencies]
 regex-automata = "0.3.6"
 env_logger = "0.9"
+criterion = "0.5"
+
+[[bench]]
+name = "form_serialize"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtg"
-version = "1.0.6"
+version = "1.1.0"
 edition = "2021"
 authors = ["Vyacheslav Shteyn <ms.vana32@gmail.com>"]
 license = "MIT"
@@ -10,8 +10,7 @@ homepage = "https://github.com/valnesfjord/vtg"
 repository = "https://github.com/valnesfjord/vtg"
 keywords = ["bots", "vk", "telegram", "api", "tg"]
 categories = ["web-programming", "api-bindings"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+exclude = ["examples/*"]
 
 [dependencies]
 hyper-tls = { version = "0.6.0", features = ["alpn"] }
@@ -27,6 +26,7 @@ serde_with = { version = "3.4.0", features = ["macros"] }
 lazy_static = "1.4.0"
 rand = "0.8.5"
 log = "0.4"
+
 [dev-dependencies]
 regex-automata = "0.3.6"
 env_logger = "0.9"

--- a/benches/form_serialize.rs
+++ b/benches/form_serialize.rs
@@ -1,0 +1,89 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::borrow::Cow;
+pub struct FastFormSerializer {
+    buffer: String,
+}
+
+impl FastFormSerializer {
+    pub fn new(pairs: &[(Cow<'_, str>, Cow<'_, str>)]) -> Self {
+        let capacity = pairs
+            .iter()
+            .map(|(k, v)| k.len() * 3 + v.len() * 3 + 2)
+            .sum();
+
+        Self {
+            buffer: String::with_capacity(capacity),
+        }
+    }
+
+    pub fn extend_pairs<'a, I>(&mut self, pairs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = &'a (Cow<'a, str>, Cow<'a, str>)>,
+    {
+        for (key, value) in pairs {
+            if !self.buffer.is_empty() {
+                self.buffer.push('&');
+            }
+
+            for &b in key.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+
+            self.buffer.push('=');
+
+            for &b in value.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+        }
+        self
+    }
+
+    pub fn finish(&mut self) -> String {
+        std::mem::take(&mut self.buffer)
+    }
+}
+
+#[inline]
+fn should_encode(byte: u8) -> bool {
+    !(byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'.' || byte == b'_' || byte == b'~')
+}
+
+#[inline]
+fn hex(byte: u8) -> String {
+    format!("{:02X}", byte)
+}
+
+fn form_serialize_benchmark(c: &mut Criterion) {
+    let test_data = vec![
+        (Cow::Borrowed("key1"), Cow::Borrowed("value1")),
+        (Cow::Borrowed("key2"), Cow::Borrowed("value2")),
+    ];
+
+    c.bench_function("form_urlencoded", |b| {
+        b.iter(|| {
+            form_urlencoded::Serializer::new(String::new())
+                .extend_pairs(black_box(&test_data))
+                .finish()
+        })
+    });
+
+    c.bench_function("fast_form", |b| {
+        b.iter(|| {
+            let mut serializer = FastFormSerializer::new(black_box(&test_data));
+            serializer.extend_pairs(&test_data).finish()
+        })
+    });
+}
+
+criterion_group!(benches, form_serialize_benchmark);
+criterion_main!(benches);

--- a/benches/form_serialize.rs
+++ b/benches/form_serialize.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::borrow::Cow;
+use vtg::structs::struct_to_vec::param;
 pub struct FastFormSerializer {
     buffer: String,
 }
@@ -15,7 +16,46 @@ impl FastFormSerializer {
             buffer: String::with_capacity(capacity),
         }
     }
+    pub fn new_vec(pairs: &[(&str, &str)]) -> Self {
+        let capacity = pairs
+            .iter()
+            .map(|(k, v)| k.len() * 3 + v.len() * 3 + 2)
+            .sum();
 
+        Self {
+            buffer: String::with_capacity(capacity),
+        }
+    }
+    pub fn extend_vec_pairs<'a, I>(&mut self, pairs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = &'a (&'a str, &'a str)>,
+    {
+        for (key, value) in pairs {
+            if !self.buffer.is_empty() {
+                self.buffer.push('&');
+            }
+            for &b in key.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+
+            self.buffer.push('=');
+
+            for &b in value.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+        }
+        self
+    }
     pub fn extend_pairs<'a, I>(&mut self, pairs: I) -> &mut Self
     where
         I: IntoIterator<Item = &'a (Cow<'a, str>, Cow<'a, str>)>,
@@ -64,23 +104,45 @@ fn hex(byte: u8) -> String {
 }
 
 fn form_serialize_benchmark(c: &mut Criterion) {
-    let test_data = vec![
-        (Cow::Borrowed("key1"), Cow::Borrowed("value1")),
-        (Cow::Borrowed("key2"), Cow::Borrowed("value2")),
-    ];
+    let test_data_vec = vec![("key1", "value1"), ("key2", "value2")];
 
-    c.bench_function("form_urlencoded", |b| {
+    let test_data_param = vec![param("key1", "value1"), param("key2", "value2")];
+    c.bench_function("vec_growing", |b| {
         b.iter(|| {
-            form_urlencoded::Serializer::new(String::new())
-                .extend_pairs(black_box(&test_data))
-                .finish()
+            let vec = vec![
+                ("dynamic1", "value1"),
+                ("dynamic2", "value2"),
+                ("dynamic3", "value2"),
+                ("dynamic4", "value2"),
+            ];
+            let mut serializer = FastFormSerializer::new_vec(&vec);
+            serializer.extend_vec_pairs(&vec).finish()
         })
     });
 
-    c.bench_function("fast_form", |b| {
+    c.bench_function("param_growing", |b| {
         b.iter(|| {
-            let mut serializer = FastFormSerializer::new(black_box(&test_data));
-            serializer.extend_pairs(&test_data).finish()
+            let vec = vec![
+                param("dynamic1", "value1"),
+                param("dynamic2", "value2"),
+                param("dynamic3", "value2"),
+                param("dynamic4", "value2"),
+            ];
+            let mut serializer = FastFormSerializer::new(&vec);
+            serializer.extend_pairs(&vec).finish()
+        })
+    });
+    c.bench_function("vec_direct", |b| {
+        b.iter(|| {
+            let mut serializer = FastFormSerializer::new_vec(black_box(&test_data_vec));
+            serializer.extend_vec_pairs(&test_data_vec).finish()
+        })
+    });
+
+    c.bench_function("vec_param", |b| {
+        b.iter(|| {
+            let mut serializer = FastFormSerializer::new(black_box(&test_data_param));
+            serializer.extend_pairs(&test_data_param).finish()
         })
     });
 }

--- a/examples/bot.rs
+++ b/examples/bot.rs
@@ -25,7 +25,7 @@ async fn catch_new_message(mut ctx: UnifyedContext) -> UnifyedContext {
         return ctx;
     }
 
-    ctx.set_data(54);
+    ctx.set_data(54.to_string());
 
     if ctx.platform == Platform::VK {
         let event = ctx.get_event::<VKMessageNew>().unwrap();

--- a/examples/bot.rs
+++ b/examples/bot.rs
@@ -6,6 +6,7 @@ use vtg::structs::{
     config::Config,
     context::{EventType, UnifyedContext},
     middleware::MiddlewareChain,
+    struct_to_vec::param,
 };
 use vtg::{
     client::start_longpoll_client,
@@ -60,7 +61,7 @@ async fn catch_tg_callback(mut ctx: UnifyedContext) -> UnifyedContext {
     ctx.api_call(
         Platform::Telegram,
         "answerCallbackQuery",
-        vec![("callback_query_id", event.id.as_str())],
+        vec![param("callback_query_id", event.id.as_str())],
     )
     .await;
 

--- a/examples/commands/api.rs
+++ b/examples/commands/api.rs
@@ -57,6 +57,7 @@ pub async fn send_with_options(ctx: UnifyedContext) {
 
 pub async fn send_with_api_request(ctx: UnifyedContext) {
     if ctx.platform == Platform::VK {
+        let start_time = std::time::Instant::now();
         vk_api::Messages::send(
             VKMessagesSendOptions {
                 peer_id: Some(ctx.peer_id),
@@ -64,21 +65,23 @@ pub async fn send_with_api_request(ctx: UnifyedContext) {
                 random_id: Some(0),
                 ..Default::default()
             },
-            ctx.config,
+            ctx.config.clone(),
         )
         .await
         .unwrap();
+        ctx.send(&format!("VK API request time: {:?}", start_time.elapsed()));
         return;
     }
-    
+    let start_time = std::time::Instant::now();
     tg_api::Api::send_message(
         TGSendMessageOptions {
             chat_id: Some(ctx.peer_id),
             text: Some("testing api requests".to_string()),
             ..Default::default()
         },
-        ctx.config,
+        ctx.config.clone(),
     )
     .await
     .unwrap();
+    ctx.send(&format!("TG API request time: {:?}", start_time.elapsed()));
 }

--- a/examples/commands/attachments.rs
+++ b/examples/commands/attachments.rs
@@ -62,7 +62,7 @@ pub async fn send_attachments(ctx: UnifyedContext) {
             },
             Attachment {
                 url:
-                    "https://w.forfun.com/fetch/a9/a908815bda3f615bfe16bef28c6389db.jpeg"
+                    "https://pivoug.ru/d/54702081_2.jpg"
                         .to_string(),
                 ftype: FileType::Photo,
             },

--- a/examples/commands/send.rs
+++ b/examples/commands/send.rs
@@ -14,7 +14,7 @@ pub async fn test_matches(ctx: UnifyedContext, caps: Captures) {
 }
 
 pub async fn test_data(ctx: UnifyedContext) {
-    let data = ctx.get_data::<i32>().unwrap();
+    let data: i32 = ctx.data.parse().unwrap();
 
     println!("Data: {:?}", data);
 
@@ -44,6 +44,6 @@ pub async fn test_event(ctx: UnifyedContext) {
             }
         }
     }
-    
+
     ctx.send("test event (check console)");
 }

--- a/src/client/api_requests.rs
+++ b/src/client/api_requests.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 use log::debug;
 use serde_json::Value;
 
-use crate::structs::context::Platform;
+use crate::structs::{context::Platform, struct_to_vec::param};
 
 use super::*;
 /// Send request to VK or Telegram API
@@ -31,7 +33,7 @@ use super::*;
 pub async fn api_call(
     platform: Platform,
     method: &str,
-    mut params: Vec<(&str, &str)>,
+    mut params: Vec<(Cow<'_, str>, Cow<'_, str>)>,
     config: &Config,
 ) -> Result<Value, String> {
     let url = match platform {
@@ -46,7 +48,7 @@ pub async fn api_call(
         Platform::Telegram => "".to_owned(),
     };
     if platform == Platform::VK {
-        params.push(("v", &config.vk_api_version));
+        params.push(param("v", &config.vk_api_version));
     }
     let response = request(&url, &access_token, params).await;
     match response {

--- a/src/client/api_requests.rs
+++ b/src/client/api_requests.rs
@@ -19,8 +19,9 @@ use super::*;
 /// # Examples
 /// ```no_run
 /// use vtg::client::api_requests::api_call;
-/// use vtg::structs::context::Platform;
-/// let response = api_call(Platform::VK, "messages.send", vec![("peer_id", "1"), ("message", "Hello, world!")], &config).await;
+/// use vtg::structs::{context::Platform, struct_to_vec::param};
+///
+/// let response = api_call(Platform::VK, "messages.send", vec![param("peer_id", "1"), param("message", "Hello, world!")], &config).await;
 /// match response {
 ///   Ok(response) => {
 ///      println!("Response: {}", response);

--- a/src/client/requests.rs
+++ b/src/client/requests.rs
@@ -1,4 +1,4 @@
-use crate::structs::context::Platform;
+use crate::{client::structs::FastFormSerializer, structs::context::Platform};
 use bytes::Bytes;
 use http_body_util::{BodyExt, Empty, Full};
 use hyper::{
@@ -14,6 +14,7 @@ use lazy_static::lazy_static;
 use log::debug;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
+use std::borrow::Cow;
 use std::io::{self, Write};
 
 /// Error enum for HyperRequestError
@@ -38,11 +39,10 @@ lazy_static! {
 pub async fn request(
     url: &str,
     access_token: &str,
-    body: Vec<(&str, &str)>,
+    body: Vec<(Cow<'_, str>, Cow<'_, str>)>,
 ) -> Result<String, HyperRequestError> {
-    let form_body = form_urlencoded::Serializer::new(String::new())
-        .extend_pairs(body.iter())
-        .finish();
+    let mut serializer = FastFormSerializer::new(&body);
+    let form_body = serializer.extend_pairs(&body).finish();
     debug!("Request body: {}", form_body);
     let req = Request::builder()
         .method(Method::POST)
@@ -137,18 +137,21 @@ pub enum FileType {
     Other,
 }
 
-impl ToString for FileType {
-    fn to_string(&self) -> String {
-        match self {
-            FileType::Photo => "Photo".to_string(),
-            FileType::Video => "Video".to_string(),
-            FileType::Audio => "Audio".to_string(),
-            FileType::Document => "Document".to_string(),
-            FileType::Voice => "Voice".to_string(),
-            FileType::VideoNote => "Video_Note".to_string(),
-            FileType::Animation => "Animation".to_string(),
-            FileType::Other => "Other".to_string(),
-        }
+use std::fmt;
+
+impl fmt::Display for FileType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            FileType::Photo => "Photo",
+            FileType::Video => "Video",
+            FileType::Audio => "Audio",
+            FileType::Document => "Document",
+            FileType::Voice => "Voice",
+            FileType::VideoNote => "Video_Note",
+            FileType::Animation => "Animation",
+            FileType::Other => "Other",
+        };
+        write!(f, "{}", s)
     }
 }
 /// Sends a POST request with the specified files data to VK or Telegram servers.

--- a/src/client/requests.rs
+++ b/src/client/requests.rs
@@ -174,10 +174,8 @@ pub async fn files_request(
     let mut body = vec![];
     let query = match data {
         Some(data) => {
-            "?".to_owned()
-                + &form_urlencoded::Serializer::new(String::new())
-                    .extend_pairs(data)
-                    .finish()
+            let mut serializer = FastFormSerializer::new_vec(&data);
+            "?".to_owned() + &serializer.extend_vec_pairs(&data).finish()
         }
         None => String::new(),
     };

--- a/src/client/structs.rs
+++ b/src/client/structs.rs
@@ -1,0 +1,63 @@
+use std::borrow::Cow;
+pub struct FastFormSerializer {
+    buffer: String,
+}
+
+impl FastFormSerializer {
+    pub fn new(pairs: &[(Cow<'_, str>, Cow<'_, str>)]) -> Self {
+        let capacity = pairs
+            .iter()
+            .map(|(k, v)| k.len() * 3 + v.len() * 3 + 2)
+            .sum();
+
+        Self {
+            buffer: String::with_capacity(capacity),
+        }
+    }
+
+    pub fn extend_pairs<'a, I>(&mut self, pairs: I) -> &mut Self
+    where
+        I: IntoIterator<Item = &'a (Cow<'a, str>, Cow<'a, str>)>,
+    {
+        for (key, value) in pairs {
+            if !self.buffer.is_empty() {
+                self.buffer.push('&');
+            }
+
+            for &b in key.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+
+            self.buffer.push('=');
+
+            for &b in value.as_bytes() {
+                if should_encode(b) {
+                    self.buffer.push('%');
+                    self.buffer.push_str(&hex(b));
+                } else {
+                    self.buffer.push(b as char);
+                }
+            }
+        }
+        self
+    }
+
+    pub fn finish(&mut self) -> String {
+        std::mem::take(&mut self.buffer)
+    }
+}
+
+#[inline]
+fn should_encode(byte: u8) -> bool {
+    !(byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'.' || byte == b'_' || byte == b'~')
+}
+
+#[inline]
+fn hex(byte: u8) -> String {
+    format!("{:02X}", byte)
+}

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -685,20 +685,25 @@ impl UnifyedContext {
             .await
             .unwrap()
     }
-    /// Set data to context
+    /// Set String data to context
     /// # Arguments
-    /// * `data` - Data to set
+    /// * `data` - String Data to set
     /// # Examples
     /// ```
-    /// ctx.set_data("Hello, world!");
+    /// ctx.set_data("Hello, world!".to_string());
     /// ```
     pub fn set_data(&mut self, data: String) {
         self.data = data;
     }
-    /// Get data from context
+    /// Deserialize JSON data from context
     /// # Examples
     /// ```
-    /// let data = ctx.get_data::<String>().unwrap();
+    /// #[derive(Deserialize)]
+    /// struct Test {
+    ///    test: String,
+    /// }
+    /// ctx.data = "{"test": "test"}".to_string();
+    /// let data = ctx.get_data::<Test>().unwrap();
     /// ```
     pub fn get_data<T: DeserializeOwned>(&self) -> Option<T> {
         serde_json::from_str(&self.data).ok()

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::any::Any;
 use std::borrow::Cow;
@@ -39,8 +40,8 @@ pub struct UnifyedContext {
     pub r#type: EventType,
     pub platform: Platform,
     pub data: Arc<Mutex<Box<dyn Any + Send + Sync>>>,
-    pub event: Arc<Mutex<Box<dyn Any + Send + Sync>>>,
-    pub attachments: Arc<Mutex<Vec<Box<dyn Any + Send + Sync>>>>,
+    pub event: String,
+    pub attachments: String,
     pub config: Arc<Config>,
 }
 
@@ -724,9 +725,8 @@ impl UnifyedContext {
     ///    }
     ///}
     /// ```
-    pub fn get_event<T: Any + Send + Sync + Clone>(&self) -> Option<T> {
-        let event = self.event.lock().unwrap();
-        event.downcast_ref::<T>().cloned()
+    pub fn get_event<T: DeserializeOwned>(&self) -> Option<T> {
+        serde_json::from_str(&self.event).ok()
     }
     /// Get attachments from context
     ///
@@ -745,12 +745,7 @@ impl UnifyedContext {
     ///       }
     ///   }
     /// ```
-    pub fn get_attachments<T: Any + Send + Sync + Clone>(&self) -> Option<Vec<T>> {
-        let attachments = self.attachments.lock().unwrap();
-        let result: Option<Vec<T>> = attachments
-            .iter()
-            .map(|attachment| attachment.downcast_ref::<T>().cloned())
-            .collect();
-        result
+    pub fn get_attachments<T: DeserializeOwned>(&self) -> Option<Vec<T>> {
+        serde_json::from_str(&self.attachments).ok()
     }
 }

--- a/src/structs/context.rs
+++ b/src/structs/context.rs
@@ -1,8 +1,7 @@
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::any::Any;
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::client::requests::File;
 use crate::structs::keyboard::{self, Keyboard};
@@ -39,7 +38,7 @@ pub struct UnifyedContext {
     pub id: i64,
     pub r#type: EventType,
     pub platform: Platform,
-    pub data: Arc<Mutex<Box<dyn Any + Send + Sync>>>,
+    pub data: String,
     pub event: String,
     pub attachments: String,
     pub config: Arc<Config>,
@@ -693,18 +692,16 @@ impl UnifyedContext {
     /// ```
     /// ctx.set_data("Hello, world!");
     /// ```
-    pub fn set_data<T: Any + Send + Sync>(&self, data: T) {
-        let mut data_to_edit = self.data.lock().unwrap();
-        *data_to_edit = Box::new(data);
+    pub fn set_data(&mut self, data: String) {
+        self.data = data;
     }
     /// Get data from context
     /// # Examples
     /// ```
     /// let data = ctx.get_data::<String>().unwrap();
     /// ```
-    pub fn get_data<T: Any + Send + Sync + Clone>(&self) -> Option<T> {
-        let data = self.data.lock().unwrap();
-        data.downcast_ref::<T>().cloned()
+    pub fn get_data<T: DeserializeOwned>(&self) -> Option<T> {
+        serde_json::from_str(&self.data).ok()
     }
     /// Get event from context
     ///

--- a/src/structs/tg.rs
+++ b/src/structs/tg.rs
@@ -136,7 +136,7 @@ pub struct TGChat {
 }
 
 impl UnifyContext for TGUpdate {
-    fn unify(&self, config: &Config) -> UnifyedContext {
+    fn unify(&self, config: Arc<Config>) -> UnifyedContext {
         let event: Arc<Mutex<Box<dyn Any + Send + Sync>>>;
         let (r#type, text, chat_id, message_id, from_id) = match self {
             TGUpdate {
@@ -211,14 +211,14 @@ impl UnifyContext for TGUpdate {
             }
         };
         UnifyedContext {
-            text: text.clone().unwrap_or("".to_owned()),
+            text: text.unwrap_or(String::new()),
             from_id,
             peer_id: chat_id,
             id: message_id,
             r#type,
             platform: Platform::Telegram,
             data: Arc::new(Mutex::new(Box::new(()))),
-            config: Arc::new(config.to_owned()),
+            config,
             event,
             attachments: unify_attachments(self.message.clone()),
         }

--- a/src/structs/tg.rs
+++ b/src/structs/tg.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::config::Config;
 use super::context::{EventType, Platform, UnifyContext, UnifyedContext};
@@ -221,7 +221,7 @@ impl UnifyContext for TGUpdate {
             id: message_id,
             r#type,
             platform: Platform::Telegram,
-            data: Arc::new(Mutex::new(Box::new(()))),
+            data: String::new(),
             config,
             event,
             attachments: unify_attachments(self.message.clone()),

--- a/src/structs/tg.rs
+++ b/src/structs/tg.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use std::sync::{Arc, Mutex};
 
@@ -22,6 +23,7 @@ pub struct TGUpdate {
     pub update_id: i64,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TGCallbackQuery {
     pub id: String,
@@ -32,6 +34,7 @@ pub struct TGCallbackQuery {
     pub inline_message_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TGChosenInlineResult {
     pub result_id: String,
@@ -40,6 +43,7 @@ pub struct TGChosenInlineResult {
     pub inline_message_id: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TGInlineQuery {
     pub id: String,
@@ -49,6 +53,7 @@ pub struct TGInlineQuery {
     pub chat_type: Option<String>,
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Clone, Debug, Default, Serialize)]
 pub struct TGMessage {
     pub text: Option<String>,

--- a/src/structs/tg_api.rs
+++ b/src/structs/tg_api.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,7 @@ use super::{
 };
 pub fn tg_api_call(
     method: &'static str,
-    params: Vec<(&'static str, &'static str)>,
+    params: Vec<(Cow<'static, str>, Cow<'static, str>)>,
     config: Arc<Config>,
 ) -> JoinHandle<Value> {
     tokio::task::spawn(async move {

--- a/src/structs/tg_attachments.rs
+++ b/src/structs/tg_attachments.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use super::tg::TGMessage;
 
@@ -204,6 +205,7 @@ pub fn unify_attachments(message: Option<TGMessage>) -> String {
     .unwrap()
 }
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TGAttachment {
     pub audio: Option<Audio>,

--- a/src/structs/tg_attachments.rs
+++ b/src/structs/tg_attachments.rs
@@ -1,8 +1,3 @@
-use std::{
-    any::Any,
-    sync::{Arc, Mutex},
-};
-
 use serde::{Deserialize, Serialize};
 
 use super::tg::TGMessage;
@@ -188,14 +183,12 @@ pub struct WebAppData {
     pub button_text: String,
 }
 
-pub fn unify_attachments(
-    message: Option<TGMessage>,
-) -> Arc<Mutex<Vec<Box<dyn Any + Send + Sync>>>> {
+pub fn unify_attachments(message: Option<TGMessage>) -> String {
     if message.is_none() {
-        return Arc::new(Mutex::new(Vec::new()));
+        return String::new();
     }
     let message = message.unwrap();
-    let attachments: Vec<Box<dyn Any + Send + Sync>> = vec![Box::new(TGAttachment {
+    serde_json::to_string(&TGAttachment {
         audio: message.audio,
         document: message.document,
         photo: message.photo,
@@ -207,8 +200,8 @@ pub fn unify_attachments(
         contact: message.contact,
         location: message.location,
         venue: message.venue,
-    })];
-    Arc::new(Mutex::new(attachments))
+    })
+    .unwrap()
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::sync::{Arc, Mutex};
 
 use super::config::Config;
@@ -34,6 +35,7 @@ pub enum VKObject {
     MessageNew(VKMessageNew),
     MessageEvent(VKMessageEvent),
 }
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct VKMessageEvent {
     pub user_id: i64,
@@ -47,6 +49,7 @@ pub struct VKMessageNew {
     pub message: VKMessage,
 }
 
+#[skip_serializing_none]
 #[derive(Deserialize, Clone, Debug, Serialize, Default)]
 /// VK Message struct, contains all the information about the new message
 pub struct VKMessage {

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::config::Config;
 use super::context::{EventType, Platform, UnifyContext, UnifyedContext};
@@ -251,7 +251,7 @@ impl UnifyContext for VKUpdate {
             id: message_id,
             r#type,
             platform: Platform::VK,
-            data: Arc::new(Mutex::new(Box::new(()))),
+            data: String::new(),
             config,
             event,
             attachments,

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -205,7 +205,7 @@ pub struct VKChatPhoto {
 }
 
 impl UnifyContext for VKUpdate {
-    fn unify(&self, config: &Config) -> UnifyedContext {
+    fn unify(&self, config: Arc<Config>) -> UnifyedContext {
         let event: Arc<Mutex<Box<dyn Any + Send + Sync>>>;
         let (r#type, text, chat_id, message_id, from_id, attachments) = match self.object.clone() {
             Some(VKObject::MessageNew(message)) => {
@@ -223,7 +223,7 @@ impl UnifyContext for VKUpdate {
                 event = Arc::new(Mutex::new(Box::new(message.clone())));
                 (
                     EventType::CallbackQuery,
-                    message.payload.clone(),
+                    message.payload,
                     message.peer_id,
                     message.conversation_message_id,
                     message.user_id,
@@ -234,7 +234,7 @@ impl UnifyContext for VKUpdate {
                 event = Arc::new(Mutex::new(Box::new(())));
                 (
                     EventType::Unknown,
-                    "".to_owned(),
+                    String::new(),
                     0,
                     0,
                     0,
@@ -243,14 +243,14 @@ impl UnifyContext for VKUpdate {
             }
         };
         UnifyedContext {
-            text: text.clone(),
+            text,
             from_id,
             peer_id: chat_id,
             id: message_id,
             r#type,
             platform: Platform::VK,
             data: Arc::new(Mutex::new(Box::new(()))),
-            config: Arc::new(config.clone()),
+            config,
             event,
             attachments,
         }

--- a/src/structs/vk_api.rs
+++ b/src/structs/vk_api.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -20,7 +21,7 @@ use super::{
 };
 pub fn vk_api_call(
     method: &'static str,
-    params: Vec<(&'static str, &'static str)>,
+    params: Vec<(Cow<'static, str>, Cow<'static, str>)>,
     config: Arc<Config>,
 ) -> JoinHandle<Value> {
     tokio::task::spawn(async move {

--- a/src/structs/vk_attachments.rs
+++ b/src/structs/vk_attachments.rs
@@ -1,9 +1,9 @@
-
-
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 use super::vk::VKMessage;
 
+#[skip_serializing_none]
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
 pub struct VKAttachment {
     pub r#type: String,

--- a/src/structs/vk_attachments.rs
+++ b/src/structs/vk_attachments.rs
@@ -1,7 +1,4 @@
-use std::{
-    any::Any,
-    sync::{Arc, Mutex},
-};
+
 
 use serde::{Deserialize, Serialize};
 
@@ -176,16 +173,14 @@ pub struct Views {
     pub count: i64,
 }
 
-pub fn unify_attachments(
-    message: Option<VKMessage>,
-) -> Arc<Mutex<Vec<Box<dyn Any + Send + Sync>>>> {
+pub fn unify_attachments(message: Option<VKMessage>) -> String {
     if message.is_none() {
-        return Arc::new(Mutex::new(Vec::new()));
+        return String::new();
     }
     let message = message.unwrap();
-    let mut attachments: Vec<Box<dyn Any + Send + Sync>> = Vec::new();
+    let mut attachments: Vec<String> = Vec::new();
     for attachment in message.attachments.unwrap_or_default() {
-        attachments.push(Box::new(attachment));
+        attachments.push(serde_json::to_string(&attachment).unwrap());
     }
-    Arc::new(Mutex::new(attachments))
+    serde_json::to_string(&attachments).unwrap()
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -9,6 +9,7 @@ use crate::{
     structs::{
         config::Config,
         context::Platform,
+        struct_to_vec::param,
         upload::{
             VKGetUploadServerResponse, VKMessageDocumentResponse, VKMessageDocumentUploaded,
             VKMessagePhotoResponse, VKMessagePhotoUploaded,
@@ -64,7 +65,7 @@ pub async fn upload_vk_attachments(
                         api_call(
                             Platform::VK,
                             "photos.getMessagesUploadServer",
-                            vec![("peer_id", &peer_id.to_string())],
+                            vec![param("peer_id", peer_id.to_string())],
                             config,
                         )
                         .await?,
@@ -80,7 +81,10 @@ pub async fn upload_vk_attachments(
                         api_call(
                             Platform::VK,
                             "docs.getMessagesUploadServer",
-                            vec![("peer_id", &peer_id.to_string()), ("type", "audio_message")],
+                            vec![
+                                param("peer_id", peer_id.to_string()),
+                                param("type", "audio_message"),
+                            ],
                             config,
                         )
                         .await?,
@@ -96,7 +100,7 @@ pub async fn upload_vk_attachments(
                         api_call(
                             Platform::VK,
                             "docs.getMessagesUploadServer",
-                            vec![("peer_id", &peer_id.to_string()), ("type", "doc")],
+                            vec![param("peer_id", peer_id.to_string()), param("type", "doc")],
                             config,
                         )
                         .await?,
@@ -121,9 +125,9 @@ pub async fn upload_vk_attachments(
                         Platform::VK,
                         "photos.saveMessagesPhoto",
                         vec![
-                            ("photo", &uploaded_photo.photo),
-                            ("server", &uploaded_photo.server.to_string()),
-                            ("hash", &uploaded_photo.hash),
+                            param("photo", uploaded_photo.photo),
+                            param("server", uploaded_photo.server.to_string()),
+                            param("hash", uploaded_photo.hash),
                         ],
                         config,
                     )
@@ -145,7 +149,7 @@ pub async fn upload_vk_attachments(
                 let server_resp = api_call(
                     Platform::VK,
                     "docs.save",
-                    vec![("file", &uploaded_doc.file)],
+                    vec![param("file", uploaded_doc.file)],
                     config,
                 )
                 .await?;
@@ -262,9 +266,9 @@ pub async fn send_tg_attachments(
             Platform::Telegram,
             &format!("send{}", ftype.replace('_', "")),
             vec![
-                ("caption", message),
-                ("chat_id", &peer_id.to_string()),
-                (&ftype.to_lowercase(), &attachments[0].url),
+                param("caption", message),
+                param("chat_id", peer_id.to_string()),
+                param(ftype.to_lowercase(), &attachments[0].url),
             ],
             config,
         )
@@ -285,8 +289,8 @@ pub async fn send_tg_attachments(
             Platform::Telegram,
             "sendMediaGroup",
             vec![
-                ("media", &format!("[{}]", media.join(","))),
-                ("chat_id", &peer_id.to_string()),
+                param("media", format!("[{}]", media.join(","))),
+                param("chat_id", peer_id.to_string()),
             ],
             config,
         )


### PR DESCRIPTION
changed all data fields in context (event, attachments, data) to be string
changed all Vec<(&str, &str)> to Vec<(Cow<'_, str>, Cow<'_, str>)> in API Requests and other functions to avoid memory leaks
optimized requests (new fast serializer)
optimized message builder (but it need to update anyway, not today)

so, this release will breaks the backwards compatibility for other vtg versions, so its 1.1.0!