### PR TITLE
vtg 1.1.1: Fix VK Longpoll, Change context event and attachments type, Rust 2024, and little improvements 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vtg"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 authors = ["Vyacheslav Shteyn <ms.vana32@gmail.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vtg"
 version = "1.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Vyacheslav Shteyn <ms.vana32@gmail.com>"]
 license = "MIT"
 description = "Library for creating VK and Telegram bots"

--- a/examples/bot.rs
+++ b/examples/bot.rs
@@ -90,7 +90,7 @@ async fn hears_middleware(ctx: UnifyedContext) -> UnifyedContext {
 
 #[tokio::main]
 async fn main() {
-    env::set_var("RUST_LOG", "vtg");
+    unsafe { env::set_var("RUST_LOG", "vtg") };
     env_logger::init();
 
     let config = Config {

--- a/examples/commands/attachments.rs
+++ b/examples/commands/attachments.rs
@@ -1,24 +1,22 @@
 use vtg::{
     client::requests::{File, FileType},
-    structs::{
-        context::{Platform, UnifyedContext},
-        tg_attachments::TGAttachment,
-        vk_attachments::VKAttachment,
-    },
+    structs::context::{EAttachment, UnifyedContext},
     upload::Attachment,
 };
 
 pub async fn test_attachments(ctx: UnifyedContext) {
     ctx.send("test attachments (check console)");
 
-    if ctx.platform == Platform::VK {
-        let attachments = ctx.get_attachments::<VKAttachment>().unwrap_or_default();
-        println!("{:?}", attachments);
-        return;
+    if let Some(attachments) = ctx.attachments {
+        match attachments {
+            EAttachment::VK(vk_attachments) => {
+                println!("VK attachments: {:?}", vk_attachments);
+            }
+            EAttachment::Telegram(tg_attachment) => {
+                println!("TG attachment: {:?}", tg_attachment);
+            }
+        }
     }
-
-    let attachments = ctx.get_attachments::<TGAttachment>().unwrap_or_default();
-    println!("{:?}", attachments);
 }
 
 pub async fn send_files(ctx: UnifyedContext) {

--- a/examples/commands/send.rs
+++ b/examples/commands/send.rs
@@ -1,9 +1,5 @@
 use regex_automata::util::captures::Captures;
-use vtg::structs::{
-    context::{EventType, Platform, UnifyedContext},
-    tg::TGMessage,
-    vk::VKMessageNew,
-};
+use vtg::structs::context::{Event, EventType, Platform, UnifyedContext};
 
 use crate::commands::get_potential_matches;
 
@@ -35,11 +31,15 @@ pub async fn test_event(ctx: UnifyedContext) {
     if ctx.r#type == EventType::MessageNew {
         match ctx.platform {
             Platform::Telegram => {
-                let event = ctx.get_event::<TGMessage>().unwrap();
+                let Event::TGMessage(event) = &ctx.event else {
+                    return;
+                };
                 println!("{:?}", event);
             }
             Platform::VK => {
-                let event = ctx.get_event::<VKMessageNew>().unwrap();
+                let Event::VKMessageNew(event) = &ctx.event else {
+                    return;
+                };
                 println!("{:?}", event);
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ use crate::structs::vk::{VKGetServerResponse, VKGetUpdates};
 async fn get_vk_updates(
     server: &mut str,
     key: &mut str,
-    ts: &mut i64,
+    ts: &mut String,
     tx: &Sender<UnifyedContext>,
     config: Arc<Config>,
 ) {
@@ -48,7 +48,7 @@ async fn get_vk_updates(
 
     let updates: VKGetUpdates = serde_json::from_str(&get_updates.unwrap_or("".to_string()))
         .unwrap_or(VKGetUpdates {
-            ts: *ts,
+            ts: ts.to_string(),
             updates: Some(vec![]),
             failed: Some(1),
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use std::{panic, sync::Arc};
 use tokio::time::interval;
 use tokio::{select, sync::Mutex};
 use tokio::{
-    sync::mpsc::{channel, Receiver, Sender},
+    sync::mpsc::{Receiver, Sender, channel},
     time::Instant,
 };
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ use crate::structs::vk::{VKGetServerResponse, VKGetUpdates};
 async fn get_vk_updates(
     server: &mut str,
     key: &mut str,
-    ts: &mut i64,
+    ts: &mut String,
     tx: &Sender<UnifyedContext>,
     config: Arc<Config>,
 ) {
@@ -61,7 +61,7 @@ async fn get_vk_updates(
         tx.send(unified).await.unwrap();
     }
 
-    *ts += 1;
+    *ts = updates.ts;
 }
 
 async fn get_vk_settings(config: Arc<Config>) -> VKGetServerResponse {
@@ -78,10 +78,7 @@ async fn get_vk_settings(config: Arc<Config>) -> VKGetServerResponse {
     .unwrap();
 
     let server: VKGetServerResponse = serde_json::from_str(&get_server).unwrap();
-    debug!(
-        "[LONGPOLL] [VK] Got longpoll server: {}",
-        server.response.server
-    );
+    debug!("[LONGPOLL] [VK] Got longpoll server: {:?}", server);
 
     server
 }
@@ -166,7 +163,7 @@ pub async fn start_longpoll_client(middleware: MiddlewareChain, config: Config) 
     let vk_settings = get_vk_settings(config.clone()).await;
     let mut server = vk_settings.response.server;
     let mut key = vk_settings.response.key;
-    let mut ts = vk_settings.response.ts.parse::<i64>().unwrap();
+    let mut ts = vk_settings.response.ts;
     let mut offset: i64 = 0;
 
     let (tx, rx): (Sender<UnifyedContext>, Receiver<UnifyedContext>) = channel(100);
@@ -206,7 +203,7 @@ pub async fn start_longpoll_client(middleware: MiddlewareChain, config: Config) 
             let vk_settings = get_vk_settings(config.clone()).await;
             server = vk_settings.response.server;
             key = vk_settings.response.key;
-            ts = vk_settings.response.ts.parse::<i64>().unwrap();
+            ts = vk_settings.response.ts;
             },
         }
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use std::{convert::Infallible, net::SocketAddr};
 use tokio::net::TcpListener;
 use tokio::signal;
-use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
+use tokio::sync::mpsc::{Receiver, Sender, channel};
 use tokio::time::Instant;
 struct Cleanup {
     config: Arc<Config>,
@@ -113,9 +113,7 @@ async fn handle_request(
 ///
 ///async fn catch_new_message(ctx: UnifyedContext) -> UnifyedContext {
 ///    ctx
-///}
-
-///#[tokio::main]
+///}///#[tokio::main]
 ///async fn main() {
 ///    let vk_access_token = env::var("VK_ACCESS_TOKEN").unwrap();
 ///    let vk_group_id = env::var("VK_GROUP_ID").unwrap();

--- a/src/structs/tg.rs
+++ b/src/structs/tg.rs
@@ -4,7 +4,7 @@ use serde_with::skip_serializing_none;
 use std::sync::Arc;
 
 use super::config::Config;
-use super::context::{EventType, Platform, UnifyContext, UnifyedContext};
+use super::context::{Event, EventType, Platform, UnifyContext, UnifyedContext};
 use super::tg_attachments::*;
 
 #[derive(Deserialize, Clone, Debug)]
@@ -141,13 +141,13 @@ pub struct TGChat {
 
 impl UnifyContext for TGUpdate {
     fn unify(&self, config: Arc<Config>) -> UnifyedContext {
-        let event: String;
+        let event: Event;
         let (r#type, text, chat_id, message_id, from_id) = match self {
             TGUpdate {
                 message: Some(message),
                 ..
             } => {
-                event = serde_json::to_string(&message).unwrap();
+                event = Event::TGMessage(message.clone());
                 (
                     EventType::MessageNew,
                     message.text.clone(),
@@ -160,7 +160,7 @@ impl UnifyContext for TGUpdate {
                 edited_message: Some(message),
                 ..
             } => {
-                event = serde_json::to_string(&message).unwrap();
+                event = Event::TGMessage(message.clone());
                 (
                     EventType::MessageEdit,
                     message.text.clone(),
@@ -173,7 +173,7 @@ impl UnifyContext for TGUpdate {
                 inline_query: Some(query),
                 ..
             } => {
-                event = serde_json::to_string(&query).unwrap();
+                event = Event::TGInlineQuery(query.clone());
                 (
                     EventType::InlineQuery,
                     Some(query.query.clone()),
@@ -186,7 +186,7 @@ impl UnifyContext for TGUpdate {
                 chosen_inline_result: Some(result),
                 ..
             } => {
-                event = serde_json::to_string(&result).unwrap();
+                event = Event::TGChosenInlineResult(result.clone());
                 (
                     EventType::ChosenInlineResult,
                     Some(result.query.clone()),
@@ -199,7 +199,7 @@ impl UnifyContext for TGUpdate {
                 callback_query: Some(query),
                 ..
             } => {
-                event = serde_json::to_string(&query).unwrap();
+                event = Event::TGCallbackQuery(query.clone());
                 (
                     EventType::CallbackQuery,
                     query.data.clone(),
@@ -210,7 +210,7 @@ impl UnifyContext for TGUpdate {
             }
 
             _ => {
-                event = String::new();
+                event = Event::Unknown;
                 (EventType::Unknown, None, 0, 0, 0)
             }
         };

--- a/src/structs/tg_attachments.rs
+++ b/src/structs/tg_attachments.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use super::tg::TGMessage;
+use super::{context::EAttachment, tg::TGMessage};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PhotoSize {
@@ -184,12 +184,10 @@ pub struct WebAppData {
     pub button_text: String,
 }
 
-pub fn unify_attachments(message: Option<TGMessage>) -> String {
-    if message.is_none() {
-        return String::new();
-    }
+pub fn unify_attachments(message: Option<TGMessage>) -> Option<EAttachment> {
+    message.as_ref()?;
     let message = message.unwrap();
-    serde_json::to_string(&TGAttachment {
+    Some(EAttachment::Telegram(Box::new(TGAttachment {
         audio: message.audio,
         document: message.document,
         photo: message.photo,
@@ -201,8 +199,7 @@ pub fn unify_attachments(message: Option<TGMessage>) -> String {
         contact: message.contact,
         location: message.location,
         venue: message.venue,
-    })
-    .unwrap()
+    })))
 }
 
 #[skip_serializing_none]

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -1,26 +1,76 @@
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::skip_serializing_none;
+use std::fmt;
 use std::sync::Arc;
 
 use super::config::Config;
 use super::context::{Event, EventType, Platform, UnifyContext, UnifyedContext};
-use super::vk_attachments::{unify_attachments, VKAttachment};
+use super::vk_attachments::{VKAttachment, unify_attachments};
 
 #[derive(Deserialize, Debug)]
 pub struct VKGetServer {
     pub key: String,
     pub server: String,
-    pub ts: String,
+    #[serde(deserialize_with = "deserialize_ts")]
+    pub ts: i64,
 }
 #[derive(Deserialize, Debug)]
 pub struct VKGetServerResponse {
     pub response: VKGetServer,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct VKGetUpdates {
-    pub ts: String,
-    pub updates: Vec<VKUpdate>,
+    pub failed: Option<i16>,
+    #[serde(deserialize_with = "deserialize_ts")]
+    pub ts: i64,
+    pub updates: Option<Vec<VKUpdate>>,
+}
+
+fn deserialize_ts<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct TSVisitor;
+
+    impl Visitor<'_> for TSVisitor {
+        type Value = i64;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or number")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<i64, E>
+        where
+            E: de::Error,
+        {
+            value.parse().map_err(de::Error::custom)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<i64, E>
+        where
+            E: de::Error,
+        {
+            Ok(value)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<i64, E>
+        where
+            E: de::Error,
+        {
+            Ok(value as i64)
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<i64, E>
+        where
+            E: de::Error,
+        {
+            value.parse().map_err(de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(TSVisitor)
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -3,7 +3,7 @@ use serde_with::skip_serializing_none;
 use std::sync::Arc;
 
 use super::config::Config;
-use super::context::{EventType, Platform, UnifyContext, UnifyedContext};
+use super::context::{Event, EventType, Platform, UnifyContext, UnifyedContext};
 use super::vk_attachments::{unify_attachments, VKAttachment};
 
 #[derive(Deserialize, Debug)]
@@ -12,7 +12,7 @@ pub struct VKGetServer {
     pub server: String,
     pub ts: String,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct VKGetServerResponse {
     pub response: VKGetServer,
 }
@@ -208,10 +208,10 @@ pub struct VKChatPhoto {
 
 impl UnifyContext for VKUpdate {
     fn unify(&self, config: Arc<Config>) -> UnifyedContext {
-        let event: String;
+        let event: Event;
         let (r#type, text, chat_id, message_id, from_id, attachments) = match self.object.clone() {
             Some(VKObject::MessageNew(message)) => {
-                event = serde_json::to_string(&message).unwrap();
+                event = Event::VKMessageNew(message.clone());
                 (
                     EventType::MessageNew,
                     message.message.text.clone(),
@@ -222,7 +222,7 @@ impl UnifyContext for VKUpdate {
                 )
             }
             Some(VKObject::MessageEvent(message)) => {
-                event = serde_json::to_string(&message).unwrap();
+                event = Event::VKMessageEvent(message.clone());
                 (
                     EventType::CallbackQuery,
                     message.payload,
@@ -233,7 +233,7 @@ impl UnifyContext for VKUpdate {
                 )
             }
             None => {
-                event = String::new();
+                event = Event::Unknown;
                 (
                     EventType::Unknown,
                     String::new(),

--- a/src/structs/vk.rs
+++ b/src/structs/vk.rs
@@ -13,7 +13,7 @@ pub struct VKGetServer {
     pub key: String,
     pub server: String,
     #[serde(deserialize_with = "deserialize_ts")]
-    pub ts: i64,
+    pub ts: String,
 }
 #[derive(Deserialize, Debug)]
 pub struct VKGetServerResponse {
@@ -24,55 +24,54 @@ pub struct VKGetServerResponse {
 pub struct VKGetUpdates {
     pub failed: Option<i16>,
     #[serde(deserialize_with = "deserialize_ts")]
-    pub ts: i64,
+    pub ts: String,
     pub updates: Option<Vec<VKUpdate>>,
 }
 
-fn deserialize_ts<'de, D>(deserializer: D) -> Result<i64, D::Error>
+fn deserialize_ts<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct TSVisitor;
 
     impl Visitor<'_> for TSVisitor {
-        type Value = i64;
+        type Value = String;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("string or number")
         }
 
-        fn visit_str<E>(self, value: &str) -> Result<i64, E>
+        fn visit_str<E>(self, value: &str) -> Result<String, E>
         where
             E: de::Error,
         {
-            value.parse().map_err(de::Error::custom)
+            Ok(value.to_string())
         }
 
-        fn visit_i64<E>(self, value: i64) -> Result<i64, E>
+        fn visit_i64<E>(self, value: i64) -> Result<String, E>
+        where
+            E: de::Error,
+        {
+            Ok(value.to_string())
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<String, E>
+        where
+            E: de::Error,
+        {
+            Ok(value.to_string())
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<String, E>
         where
             E: de::Error,
         {
             Ok(value)
         }
-
-        fn visit_u64<E>(self, value: u64) -> Result<i64, E>
-        where
-            E: de::Error,
-        {
-            Ok(value as i64)
-        }
-
-        fn visit_string<E>(self, value: String) -> Result<i64, E>
-        where
-            E: de::Error,
-        {
-            value.parse().map_err(de::Error::custom)
-        }
     }
 
     deserializer.deserialize_any(TSVisitor)
 }
-
 #[derive(Deserialize, Clone, Debug)]
 pub struct VKUpdate {
     pub r#type: String,

--- a/src/structs/vk_attachments.rs
+++ b/src/structs/vk_attachments.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
-use super::vk::VKMessage;
+use super::{context::EAttachment, vk::VKMessage};
 
 #[skip_serializing_none]
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -173,14 +173,12 @@ pub struct Views {
     pub count: i64,
 }
 
-pub fn unify_attachments(message: Option<VKMessage>) -> String {
-    if message.is_none() {
-        return String::new();
-    }
+pub fn unify_attachments(message: Option<VKMessage>) -> Option<EAttachment> {
+    message.as_ref()?;
     let message = message.unwrap();
-    let mut attachments: Vec<String> = Vec::new();
+    let mut attachments: Vec<VKAttachment> = Vec::new();
     for attachment in message.attachments.unwrap_or_default() {
-        attachments.push(serde_json::to_string(&attachment).unwrap());
+        attachments.push(attachment);
     }
-    serde_json::to_string(&attachments).unwrap()
+    Some(EAttachment::VK(attachments))
 }


### PR DESCRIPTION
# VTG 1.1.1: Major Type System Update & VK Longpoll Fixes 

## 🚀 Major Changes

### Event System Overhaul
* Strongly-typed event handling with unified `Event` enum
* Improved type safety and error handling
* Platform-specific event types unified

### Attachment System Changes
* New `EAttachment` enum for both platforms
* Direct access to platform-specific attachments
* Type-safe attachment handling

### VK Longpoll Improvements
* Fixed timestamp handling with custom deserializer
* Better error recovery
* Improved string/integer type conversion

### Core Updates
* Upgraded to Rust 2024 edition
* Enhanced error messages

## 📝 Example Usage

```rust
// Event Handling
 if ctx.r#type == EventType::MessageNew {
      match ctx.platform {
          Platform::Telegram => {
              let Event::TGMessage(event) = &ctx.event else {
                  return;
              };
              println!("{:?}", event);
          }
          Platform::VK => {
              let Event::VKMessageNew(event) = &ctx.event else {
                  return;
              };
              println!("{:?}", event);
          }
      }
 }

// Attachment Processing
if let Some(attachments) = ctx.attachments {
    match attachments {
        EAttachment::VK(vk_attachments) => {
            println!("VK attachments: {:?}", vk_attachments);
        },
        EAttachment::Telegram(tg_attachment) => {
            println!("TG attachment: {:?}", tg_attachment);
        }
    }
}
```

## 🔄 Type System Changes

### New Event Type
```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub enum Event {
    VKMessageNew(VKMessageNew),
    VKMessageEvent(VKMessageEvent),
    TGMessage(TGMessage),
    TGEditedMessage(TGMessage),
    TGCallbackQuery(TGCallbackQuery),
    TGInlineQuery(TGInlineQuery),
    TGChosenInlineResult(TGChosenInlineResult),
}
```

### New Attachment Type
```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub enum EAttachment {
    VK(Vec<VKAttachment>),
    Telegram(TGAttachment),
}
```

## 🐛 Fixed Issues
* VK Longpoll timestamp type mismatches
* Event type safety issues
* Attachment handling inconsistencies

## 📚 Documentation
* [API Reference](https://docs.rs/vtg)
* [GitHub Repository](https://github.com/valnesfjord/vtg)
* [Examples](https://github.com/valnesfjord/vtg/tree/master/examples)

---

Report issues on [GitHub](https://github.com/valnesfjord/vtg/issues)